### PR TITLE
update prometheus port name

### DIFF
--- a/examples/prometheus-rep-0.yaml
+++ b/examples/prometheus-rep-0.yaml
@@ -97,7 +97,7 @@ spec:
           image: prom/prometheus:v2.19.2
           ports:
             - containerPort: 9090
-              name: web
+              name: server
               protocol: TCP
           volumeMounts:
             - mountPath: /etc/prometheus/config


### PR DESCRIPTION
there are two ports in prometheus pod named web, it's ambiguous when servce call port with name web