### PR TITLE
fix examples config

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -48,7 +48,7 @@ data:
     - name: count
       rules:
       - expr: |
-          count(metrics0)
+          count(a00000000000metrics0)
         record: metrics_count
 
 

--- a/examples/prometheus-rep-0.yaml
+++ b/examples/prometheus-rep-0.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: thanos
-          image: thanosio/thanos:v0.16.0-rc.1
+          image: thanosio/thanos:v0.18.0
           args:
             - sidecar
             - --tsdb.path=/prometheus
@@ -123,19 +123,6 @@ spec:
           name: config-out
         - emptyDir: {}
           name: tls-assets
-  volumeClaimTemplates:
-    - metadata:
-        labels:
-          k8s-app: prometheus
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 10Gi
-        storageClassName: cbs
-        volumeMode: Filesystem
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/examples/thanos-query.yaml
+++ b/examples/thanos-query.yaml
@@ -40,9 +40,15 @@ spec:
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:9090
             - --query.partial-response
-            - --store=dnssrv+_grpc._tcp.prometheus.default.svc.cluster.local
-            - --store=dnssrv+_grpc._tcp.thanos-rule.default.svc.cluster.local
-          image: thanosio/thanos:v0.16.0-rc.1
+            - --store=dnssrv+_grpc._tcp.prometheus.$(NAMESPACE).svc.cluster.local
+            - --store=dnssrv+_grpc._tcp.thanos-rule.$(NAMESPACE).svc.cluster.local
+          image: thanosio/thanos:v0.18.0
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           livenessProbe:
             failureThreshold: 4
             httpGet:

--- a/examples/thanos-rule.yaml
+++ b/examples/thanos-rule.yaml
@@ -45,10 +45,16 @@ spec:
             - --grpc-address=:10901
             - --http-address=:10902
             - --data-dir=/var/thanos/rule
-            - --query=dnssrv+_http._tcp.thanos-query.default.svc.cluster.local
+            - --query=dnssrv+_http._tcp.thanos-query.$(NAMESPACE).svc.cluster.local
             - --eval-interval=10s
             - --tsdb.retention=3h
-          image: thanosio/thanos:v0.16.0-rc.1
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: thanosio/thanos:v0.18.0
           volumeMounts:
           - mountPath: /etc/thanos/rules
             name: rules


### PR DESCRIPTION
Fix config in [examples](https://github.com/tkestack/kvass/tree/master/examples)
- wrong metric name in https://github.com/tkestack/kvass/blob/ca69a26002c78f829ff1eab5b4d1dc91fd9cfabc/examples/config.yaml#L51
-  set namespace by env in `thanos-query.yaml` and `thanos-rule.yaml`
- remove `volumeClaimTemplates` in `prometheus.yaml`, it's not neccessary to create storageclass
- update thanos release version