### PR TITLE
fix: fetching head series

### DIFF
--- a/cmd/kvass/coordinator.go
+++ b/cmd/kvass/coordinator.go
@@ -117,7 +117,7 @@ distribution targets to shards`,
 				Format: format,
 			})
 
-			scrapeManager          = scrape.New()
+			scrapeManager          = scrape.New(lg.WithField("component", "scrape discovery"))
 			discoveryManagerScrape = prom_discovery.NewManager(context.Background(), log.With(logger, "component", "discovery manager scrape"), prom_discovery.Name("scrape"))
 			targetDiscovery        = discovery.New(lg.WithField("component", "target discovery"))
 			exp                    = explore.New(scrapeManager, lg.WithField("component", "explore"))

--- a/cmd/kvass/sidecar.go
+++ b/cmd/kvass/sidecar.go
@@ -103,7 +103,13 @@ var sidecarCmd = &cobra.Command{
 
 		service := sidecar.NewService(
 			sidecarCfg.prometheusURL,
-			promCli.RuntimeInfo,
+			func() (i int64, e error) {
+				ts, err := promCli.TSDBInfo()
+				if err != nil {
+					return 0, err
+				}
+				return ts.HeadStats.NumSeries, nil
+			},
 			configManager,
 			targetManager,
 			log.WithField("component", "web"),

--- a/cmd/kvass/sidecar.go
+++ b/cmd/kvass/sidecar.go
@@ -67,7 +67,7 @@ var sidecarCmd = &cobra.Command{
 		}
 		var (
 			lg            = log.New()
-			scrapeManager = scrape.New()
+			scrapeManager = scrape.New(log.WithField("component", "scrape manager"))
 			configManager = prom.NewConfigManager(sidecarCfg.configFile, log.WithField("component", "config manager"))
 			targetManager = sidecar.NewTargetsManager(sidecarCfg.storePath, log.WithField("component", "targets manager"))
 

--- a/pkg/coordinator/rebalance.go
+++ b/pkg/coordinator/rebalance.go
@@ -213,7 +213,6 @@ func (c *Coordinator) alleviateShards(changeAbleShards []*shardInfo) (needSpace 
 	for _, s := range changeAbleShards {
 		for _, t := range threshold {
 			if s.runtime.HeadSeries >= seriesWithRate(c.maxSeries, t.maxSeriesRate) {
-				c.log.Infof("%s series is %d, over rate %f", s.shard.ID, s.runtime.HeadSeries, t.maxSeriesRate)
 				needSpace += c.alleviateShard(s, changeAbleShards, seriesWithRate(c.maxSeries, t.expectSeriesRate))
 				break
 			}

--- a/pkg/coordinator/rebalance.go
+++ b/pkg/coordinator/rebalance.go
@@ -213,6 +213,7 @@ func (c *Coordinator) alleviateShards(changeAbleShards []*shardInfo) (needSpace 
 	for _, s := range changeAbleShards {
 		for _, t := range threshold {
 			if s.runtime.HeadSeries >= seriesWithRate(c.maxSeries, t.maxSeriesRate) {
+				c.log.Infof("%s series is %d, over rate %d", s.shard.ID, s.runtime.HeadSeries, t.maxSeriesRate)
 				needSpace += c.alleviateShard(s, changeAbleShards, seriesWithRate(c.maxSeries, t.expectSeriesRate))
 				break
 			}

--- a/pkg/coordinator/rebalance.go
+++ b/pkg/coordinator/rebalance.go
@@ -213,7 +213,7 @@ func (c *Coordinator) alleviateShards(changeAbleShards []*shardInfo) (needSpace 
 	for _, s := range changeAbleShards {
 		for _, t := range threshold {
 			if s.runtime.HeadSeries >= seriesWithRate(c.maxSeries, t.maxSeriesRate) {
-				c.log.Infof("%s series is %d, over rate %d", s.shard.ID, s.runtime.HeadSeries, t.maxSeriesRate)
+				c.log.Infof("%s series is %d, over rate %f", s.shard.ID, s.runtime.HeadSeries, t.maxSeriesRate)
 				needSpace += c.alleviateShard(s, changeAbleShards, seriesWithRate(c.maxSeries, t.expectSeriesRate))
 				break
 			}

--- a/pkg/explore/explore_test.go
+++ b/pkg/explore/explore_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestExplore_UpdateTargets(t *testing.T) {
-	e := New(scrape.New(), logrus.New())
+	e := New(scrape.New(logrus.New()), logrus.New())
 	require.Nil(t, e.Get(1))
 	e.UpdateTargets(map[string][]*discovery.SDTargets{
 		"job1": {&discovery.SDTargets{
@@ -54,7 +54,7 @@ func TestExplore_UpdateTargets(t *testing.T) {
 
 func TestExplore_Run(t *testing.T) {
 	r := require.New(t)
-	sm := scrape.New()
+	sm := scrape.New(logrus.New())
 	r.NoError(sm.ApplyConfig(&prom.ConfigInfo{
 		RawContent: nil,
 		ConfigHash: "",
@@ -121,7 +121,7 @@ func TestExplore_Run(t *testing.T) {
 
 func TestExplore_ApplyConfig(t *testing.T) {
 	r := require.New(t)
-	e := New(scrape.New(), logrus.New())
+	e := New(scrape.New(logrus.New()), logrus.New())
 	e.UpdateTargets(map[string][]*discovery.SDTargets{
 		"job1": {&discovery.SDTargets{
 			ShardTarget: &target.Target{

--- a/pkg/prom/client.go
+++ b/pkg/prom/client.go
@@ -35,11 +35,10 @@ func NewClient(url string) *Client {
 	}
 }
 
-// RuntimeInfo return the current status of this shard, only return tManager targets if scrapingOnly is true,
-// otherwise ,all target this cli discovered will be returned
-func (c *Client) RuntimeInfo() (*RuntimeInfo, error) {
-	ret := &RuntimeInfo{}
-	return ret, api.Get(c.url+"/api/v1/status/runtimeinfo", ret)
+// TSDBInfo return the current head status of this shard
+func (c *Client) TSDBInfo() (*TSDBInfo, error) {
+	ret := &TSDBInfo{}
+	return ret, api.Get(c.url+"/api/v1/status/tsdb", ret)
 }
 
 // Targets is compatible with prometheusURL /api/v1/targets

--- a/pkg/prom/client_test.go
+++ b/pkg/prom/client_test.go
@@ -31,18 +31,20 @@ func dataServer(data string) *httptest.Server {
 	}))
 }
 
-func TestClient_RuntimeInfo(t *testing.T) {
+func TestClient_TSDBInfo(t *testing.T) {
 	w := dataServer(`{
   "status": "success",
   "data": {
-    "timeSeriesCount": 5
-  }
+    "headStats": {
+       "numSeries": 508
+     }
+    }
 }`)
 	defer w.Close()
 	c := NewClient(w.URL)
-	r, err := c.RuntimeInfo()
+	r, err := c.TSDBInfo()
 	require.NoError(t, err)
-	require.Equal(t, int64(5), r.TimeSeriesCount)
+	require.Equal(t, int64(508), r.HeadStats.NumSeries)
 }
 
 func TestClient_ConfigReload(t *testing.T) {

--- a/pkg/prom/data.go
+++ b/pkg/prom/data.go
@@ -5,3 +5,12 @@ type RuntimeInfo struct {
 	// TimeSeriesCount is the series the prometheus head check handled
 	TimeSeriesCount int64 `json:"timeSeriesCount"`
 }
+
+// TSDBInfo include some filed the prometheus API /api/v1/status/tsdb returned
+type TSDBInfo struct {
+	// HeadStats include information of current head block
+	HeadStats struct {
+		// NumSeries is current series in head block (in memory)
+		NumSeries int64 `json:"numSeries"`
+	} `json:"headStats"`
+}

--- a/pkg/scrape/manager.go
+++ b/pkg/scrape/manager.go
@@ -1,18 +1,20 @@
 package scrape
 
 import (
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"tkestack.io/kvass/pkg/prom"
 )
 
 // Manager includes all jobs
 type Manager struct {
 	jobs map[string]*JobInfo
+	lg   logrus.FieldLogger
 }
 
 // New create a Manager with specified Cli set
-func New() *Manager {
+func New(lg logrus.FieldLogger) *Manager {
 	return &Manager{
+		lg:   lg,
 		jobs: map[string]*JobInfo{},
 	}
 }
@@ -23,7 +25,8 @@ func (s *Manager) ApplyConfig(cfg *prom.ConfigInfo) error {
 	for _, cfg := range cfg.Config.ScrapeConfigs {
 		info, err := newJobInfo(*cfg)
 		if err != nil {
-			return errors.Wrap(err, cfg.JobName)
+			s.lg.Error(err.Error())
+			continue
 		}
 		ret[cfg.JobName] = info
 	}

--- a/pkg/scrape/manager_test.go
+++ b/pkg/scrape/manager_test.go
@@ -4,6 +4,7 @@ import (
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"net/url"
 	"os"
@@ -22,7 +23,7 @@ func TestManager(t *testing.T) {
 	cfg.ScrapeTimeout = model.Duration(time.Second)
 	r.NoError(os.Setenv("SCRAPE_PROXY", "http://127.0.0.1:9090"))
 
-	ss := New()
+	ss := New(logrus.New())
 	r.NoError(ss.ApplyConfig(&prom.ConfigInfo{
 		Config: &config.Config{
 			ScrapeConfigs: []*config.ScrapeConfig{cfg},

--- a/pkg/shard/kubernetes/replicasmanager.go
+++ b/pkg/shard/kubernetes/replicasmanager.go
@@ -76,7 +76,7 @@ func (g *ReplicasManager) Replicas() ([]shard.Manager, error) {
 			continue
 		}
 
-		if g.stsUpdatedTime[s.Name] == nil {
+		if s.Status.ReadyReplicas != s.Status.Replicas && g.stsUpdatedTime[s.Name] == nil {
 			t := time.Now()
 			g.lg.Warnf("Statefulset %s is not ready, try wait 2m", s.Name)
 			g.stsUpdatedTime[s.Name] = &t

--- a/pkg/sidecar/service_test.go
+++ b/pkg/sidecar/service_test.go
@@ -62,8 +62,8 @@ func TestService_ServeHTTP(t *testing.T) {
 			}))
 			defer tProm.Close()
 
-			a := NewService(tProm.URL, func() (info *prom.RuntimeInfo, e error) {
-				return nil, nil
+			a := NewService(tProm.URL, func() (int64, error) {
+				return int64(0), nil
 			}, prom.NewConfigManager("", logrus.New()), NewTargetsManager("", logrus.New()), logrus.New())
 			a.ginEngine.POST(a.path("/test"), func(context *gin.Context) {})
 
@@ -89,15 +89,15 @@ func TestService_Run(t *testing.T) {
 func TestService_RuntimeInfo(t *testing.T) {
 	cases := []struct {
 		name               string
-		getPromRuntimeInfo func() (*prom.RuntimeInfo, error)
+		getPromRuntimeInfo func() (int64, error)
 		targets            *shard.UpdateTargetsRequest
 		configContent      string
 		wantAPIResult      *api.Result
 	}{
 		{
 			name: "prometheus head series return err",
-			getPromRuntimeInfo: func() (r *prom.RuntimeInfo, e error) {
-				return nil, fmt.Errorf("err")
+			getPromRuntimeInfo: func() (int64, error) {
+				return 0, fmt.Errorf("err")
 			},
 			targets:       &shard.UpdateTargetsRequest{},
 			configContent: "global:",
@@ -105,8 +105,8 @@ func TestService_RuntimeInfo(t *testing.T) {
 		},
 		{
 			name: "prometheus head series < total series of all targets",
-			getPromRuntimeInfo: func() (info *prom.RuntimeInfo, e error) {
-				return &prom.RuntimeInfo{TimeSeriesCount: 1}, nil
+			getPromRuntimeInfo: func() (int64, error) {
+				return 1, nil
 			},
 			targets: &shard.UpdateTargetsRequest{
 				Targets: map[string][]*target.Target{
@@ -134,8 +134,8 @@ scrape_configs:
 		},
 		{
 			name: "prometheus head series > total series of all targets",
-			getPromRuntimeInfo: func() (info *prom.RuntimeInfo, e error) {
-				return &prom.RuntimeInfo{TimeSeriesCount: 100}, nil
+			getPromRuntimeInfo: func() (int64, error) {
+				return 100, nil
 			},
 			targets: &shard.UpdateTargetsRequest{
 				Targets: map[string][]*target.Target{


### PR DESCRIPTION
using /api/v1/status/runtimeinfo to fetch head series from prometheus is incompatible with high version prometheus.
we use /api/v1/status/tsdb now.