### PR TITLE
feat: support static shards

### DIFF
--- a/deploy/demo/prometheus-rep-0.yaml
+++ b/deploy/demo/prometheus-rep-0.yaml
@@ -130,18 +130,19 @@ spec:
           name: config-out
         - emptyDir: {}
           name: tls-assets
-  volumeClaimTemplates:
-    - metadata:
-        labels:
-          k8s-app: prometheus
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 10Gi
-        volumeMode: Filesystem
+#  volumeClaimTemplates:
+#    - metadata:
+#        labels:
+#          k8s-app: prometheus
+#        name: data
+#      spec:
+#        accessModes:
+#          - ReadWriteOnce
+#        resources:
+#          requests:
+#            storage: 10Gi
+#        storageClassName: cbs
+#        volumeMode: Filesystem
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/pkg/api/testing.go
+++ b/pkg/api/testing.go
@@ -31,7 +31,7 @@ import (
 
 // TestCall create a httptest server and do http request to it
 // the data in params will be write to server and the ret in params is deemed to the Data of common Result
-func TestCall(t *testing.T, serveHTTP func(w http.ResponseWriter, req *http.Request), uri, method, data string, ret interface{}) *require.Assertions {
+func TestCall(t *testing.T, serveHTTP func(w http.ResponseWriter, req *http.Request), uri, method, data string, ret interface{}) (*require.Assertions, *Result) {
 	gin.SetMode(gin.ReleaseMode)
 	req := httptest.NewRequest(method, uri, strings.NewReader(data))
 	w := httptest.NewRecorder()
@@ -43,13 +43,14 @@ func TestCall(t *testing.T, serveHTTP func(w http.ResponseWriter, req *http.Requ
 	r := require.New(t)
 	body, err := ioutil.ReadAll(result.Body)
 	r.NoError(err)
-
+	resObj := &Result{Data: ret}
+	if len(body) != 0 {
+		_ = json.Unmarshal(body, resObj)
+	}
 	if ret != nil {
-		resObj := &Result{Data: ret}
-		r.NoError(json.Unmarshal(body, resObj), string(body))
 		r.Equal(StatusSuccess, resObj.Status)
 		r.Empty(resObj.Err)
 		r.Empty(resObj.ErrorType)
 	}
-	return r
+	return r, resObj
 }

--- a/pkg/coordinator/coordinator_test.go
+++ b/pkg/coordinator/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 	"tkestack.io/kvass/pkg/discovery"
+	"tkestack.io/kvass/pkg/prom"
 	"tkestack.io/kvass/pkg/shard"
 	"tkestack.io/kvass/pkg/target"
 	"tkestack.io/kvass/pkg/utils/test"
@@ -567,8 +568,15 @@ func TestCoordinator_RunOnce(t *testing.T) {
 
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
-			c := NewCoordinator(&fakeReplicasManager{cs.shardManager}, cs.maxSeries, cs.maxShard, cs.minShard, cs.maxIdleTime, cs.period, func() string {
-				return ""
+			option := &Option{
+				MaxSeries:   cs.maxSeries,
+				MaxShard:    cs.maxShard,
+				MinShard:    cs.minShard,
+				MaxIdleTime: cs.maxIdleTime,
+				Period:      cs.period,
+			}
+			c := NewCoordinator(option, &fakeReplicasManager{cs.shardManager}, func() *prom.ConfigInfo {
+				return prom.DefaultConfig
 			}, cs.getExploreResult, cs.getActive, logrus.New())
 			require.NoError(t, c.runOnce())
 			cs.shardManager.assert(t)
@@ -614,8 +622,15 @@ func TestCoordinator_LastGlobalScrapeStatus(t *testing.T) {
 		}
 	}
 
-	c := NewCoordinator(&fakeReplicasManager{shardManager}, 100, 100, 100, 0, time.Second, func() string {
-		return ""
+	option := &Option{
+		MaxSeries:   100,
+		MaxShard:    100,
+		MinShard:    100,
+		MaxIdleTime: time.Second,
+		Period:      0,
+	}
+	c := NewCoordinator(option, &fakeReplicasManager{shardManager}, func() *prom.ConfigInfo {
+		return prom.DefaultConfig
 	}, getStatus, active, logrus.New())
 
 	r := require.New(t)

--- a/pkg/shard/kubernetes/shardmanager.go
+++ b/pkg/shard/kubernetes/shardmanager.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"tkestack.io/kvass/pkg/shard"
-	"tkestack.io/kvass/pkg/utils/k8sutil"
 )
 
 // shardManager manager shards use kubernetes shardManager
@@ -73,7 +72,7 @@ func (s *shardManager) Shards() ([]*shard.Shard, error) {
 	ret := make([]*shard.Shard, 0)
 	for _, p := range pods.Items {
 		url := fmt.Sprintf("http://%s:%d", p.Status.PodIP, s.port)
-		ret = append(ret, shard.NewShard(p.Name, url, k8sutil.IsPodReady(&p), s.lg.WithField("shard", p.Name)))
+		ret = append(ret, shard.NewShard(p.Name, url, p.Status.PodIP != "", s.lg.WithField("shard", p.Name)))
 	}
 
 	return ret, nil

--- a/pkg/shard/shard.go
+++ b/pkg/shard/shard.go
@@ -87,6 +87,11 @@ func (r *Shard) TargetStatus() (map[uint64]*target.ScrapeStatus, error) {
 	return res, nil
 }
 
+// UpdateConfig try update shard config by API
+func (r *Shard) UpdateConfig(req *UpdateConfigRequest) error {
+	return r.APIPost(r.url+"/api/v1/status/config", req, nil)
+}
+
 // UpdateTarget try apply targets to sidecar
 // request will be skipped if nothing changed according to r.scraping
 func (r *Shard) UpdateTarget(request *UpdateTargetsRequest) error {

--- a/pkg/shard/static/replicasmanager.go
+++ b/pkg/shard/static/replicasmanager.go
@@ -1,0 +1,59 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package static
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"tkestack.io/kvass/pkg/shard"
+)
+
+// ReplicasManager create replicas from static
+type ReplicasManager struct {
+	file string
+	log  logrus.FieldLogger
+}
+
+// NewReplicasManager return an new static shard replicas manager
+func NewReplicasManager(file string, log logrus.FieldLogger) *ReplicasManager {
+	return &ReplicasManager{
+		file: file,
+		log:  log,
+	}
+}
+
+// Replicas return all shards manager
+func (g *ReplicasManager) Replicas() ([]shard.Manager, error) {
+	content, err := ioutil.ReadFile(g.file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read config file")
+	}
+	config := &staticConfig{}
+	if err := yaml.Unmarshal(content, config); err != nil {
+		return nil, errors.Wrapf(err, "wrong format of shard config")
+	}
+
+	ret := make([]shard.Manager, 0)
+	for _, r := range config.Replicas {
+		ret = append(ret, newShardManager(r.Shards, g.log))
+	}
+
+	return ret, nil
+}

--- a/pkg/shard/static/shardmanager.go
+++ b/pkg/shard/static/shardmanager.go
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package static
+
+import (
+	"github.com/sirupsen/logrus"
+	"tkestack.io/kvass/pkg/shard"
+)
+
+type shardManager struct {
+	shards []shardConfig
+	log    logrus.FieldLogger
+}
+
+func newShardManager(shards []shardConfig, log logrus.FieldLogger) *shardManager {
+	return &shardManager{
+		shards: shards,
+		log:    log,
+	}
+}
+
+// Shards return current Shards in the cluster
+func (s *shardManager) Shards() ([]*shard.Shard, error) {
+	ret := make([]*shard.Shard, 0)
+	for _, sd := range s.shards {
+		ret = append(ret, shard.NewShard(sd.ID, sd.URL, true, s.log.WithField("shard", sd.ID)))
+	}
+	return ret, nil
+}
+
+// ChangeScale create or delete Shards according to "expReplicate"
+// static shard can not change scale
+func (s *shardManager) ChangeScale(expReplicate int32) error {
+	return nil
+}

--- a/pkg/shard/static/shardmanager_test.go
+++ b/pkg/shard/static/shardmanager_test.go
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package static
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestShardManager_Shards(t *testing.T) {
+	shards := []shardConfig{
+		{
+			ID:  "0",
+			URL: "http://1.1.1.1",
+		},
+	}
+	m := newShardManager(shards, logrus.New())
+	sd, err := m.Shards()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sd))
+	require.Equal(t, shards[0].ID, sd[0].ID)
+}
+
+func TestShardManager_ChangeScale(t *testing.T) {
+	m := newShardManager(nil, logrus.New())
+	require.NoError(t, m.ChangeScale(0))
+}

--- a/pkg/shard/static/types.go
+++ b/pkg/shard/static/types.go
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package static
+
+type shardConfig struct {
+	// ID is the unique id of this shard
+	ID string `yaml:"id"`
+	// URL for coordinator to communicate with shards
+	URL string `yaml:"url"`
+}
+
+type staticConfig struct {
+	// Replicas indicate all replicas information
+	Replicas []struct {
+		// Shards is all shard mem of one replica
+		Shards []shardConfig `yaml:"shards"`
+	} `yaml:"replicas"`
+}

--- a/pkg/shard/types.go
+++ b/pkg/shard/types.go
@@ -51,3 +51,8 @@ type UpdateTargetsRequest struct {
 	// targets contains all targets this shard should scrape
 	Targets map[string][]*target.Target
 }
+
+// UpdateConfigRequest is request struct for POST /
+type UpdateConfigRequest struct {
+	RawContent string `json:"rawContent"`
+}

--- a/pkg/sidecar/injector.go
+++ b/pkg/sidecar/injector.go
@@ -74,6 +74,7 @@ func NewInjector(outFile string, option InjectConfigOptions, log logrus.FieldLog
 		curTargets: map[string][]*target.Target{},
 		writeFile:  ioutil.WriteFile,
 		log:        log,
+		curCfg:     prom.DefaultConfig,
 	}
 }
 
@@ -199,6 +200,10 @@ func (i *Injector) marshal(cfg *config.Config) ([]byte, error) {
 func (i *Injector) inject() error {
 	i.Lock()
 	defer i.Unlock()
+	// create a default empty config for prometheus and thanos sidecar
+	if i.curCfg == prom.DefaultConfig {
+		return i.writeFile(i.outFile, i.curCfg.RawContent, 0755)
+	}
 
 	cfg := &config.Config{}
 	if err := yaml.Unmarshal(i.curCfg.RawContent, &cfg); err != nil {

--- a/pkg/sidecar/service_test.go
+++ b/pkg/sidecar/service_test.go
@@ -17,6 +17,7 @@
 package sidecar
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -62,19 +63,19 @@ func TestService_ServeHTTP(t *testing.T) {
 			}))
 			defer tProm.Close()
 
-			a := NewService(tProm.URL, func() (int64, error) {
+			a := NewService("", tProm.URL, func() (int64, error) {
 				return int64(0), nil
-			}, prom.NewConfigManager("", logrus.New()), NewTargetsManager("", logrus.New()), logrus.New())
+			}, prom.NewConfigManager(), NewTargetsManager("", logrus.New()), logrus.New())
 			a.ginEngine.POST(a.path("/test"), func(context *gin.Context) {})
 
-			r := api.TestCall(t, a.ServeHTTP, cs.uri, http.MethodGet, "", nil)
+			r, _ := api.TestCall(t, a.ServeHTTP, cs.uri, http.MethodGet, "", nil)
 			r.Equal(cs.wantCall, promCalled)
 		})
 	}
 }
 
 func TestService_Run(t *testing.T) {
-	s := NewService("", nil, nil, nil, logrus.New())
+	s := NewService("", "", nil, nil, nil, logrus.New())
 	r := require.New(t)
 	called := false
 	s.runHTTP = func(addr string, handler http.Handler) error {
@@ -170,10 +171,10 @@ scrape_configs:
 
 			cfg := path.Join(t.TempDir(), "config.yaml")
 			r.NoError(ioutil.WriteFile(cfg, []byte(cs.configContent), 0755))
-			cfgMa := prom.NewConfigManager(cfg, logrus.New())
-			r.NoError(cfgMa.Reload())
+			cfgMa := prom.NewConfigManager()
+			r.NoError(cfgMa.ReloadFromFile(cfg))
 
-			s := NewService("", cs.getPromRuntimeInfo, cfgMa, tm, logrus.New())
+			s := NewService("", "", cs.getPromRuntimeInfo, cfgMa, tm, logrus.New())
 			res := s.runtimeInfo(nil)
 			r.Equal(cs.wantAPIResult.Status, res.Status)
 			if res.Status != api.StatusError {
@@ -202,7 +203,7 @@ func TestService_UpdateTargets(t *testing.T) {
 
 	r := require.New(t)
 	tm := NewTargetsManager(t.TempDir(), logrus.New())
-	s := NewService("", nil, nil, tm, logrus.New())
+	s := NewService("", "", nil, nil, tm, logrus.New())
 	s.ServeHTTP(w, req)
 	result := w.Result()
 	r.Equal(200, result.StatusCode)
@@ -220,4 +221,78 @@ func TestService_UpdateTargets(t *testing.T) {
 			1: target.NewScrapeStatus(1),
 		},
 	}), test.MustJSON(tm.TargetsInfo()))
+}
+
+func TestNewService_UpdateConfig(t *testing.T) {
+	type caseInfo struct {
+		configFile  string
+		content     string
+		wantErr     bool
+		wantUpdated bool
+	}
+
+	successCase := func() *caseInfo {
+		return &caseInfo{
+			configFile: "",
+			content: `global:
+  evaluation_interval: 10s
+  scrape_interval: 15s
+scrape_configs:
+- job_name: "test"
+  static_configs:
+  - targets:
+    - 127.0.0.1:9091`,
+			wantErr:     false,
+			wantUpdated: true,
+		}
+	}
+
+	var cases = []struct {
+		desc       string
+		updateCase func(c *caseInfo)
+	}{
+		{
+			desc:       "success",
+			updateCase: func(c *caseInfo) {},
+		},
+		{
+			desc: "config file not empty, update config from raw data is not allowed",
+			updateCase: func(c *caseInfo) {
+				c.configFile = "xx"
+				c.wantErr = true
+				c.wantUpdated = false
+			},
+		},
+		{
+			desc: "wrong data format, want err",
+			updateCase: func(c *caseInfo) {
+				c.content = `a : a :`
+				c.wantErr = true
+				c.wantUpdated = false
+			},
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.desc, func(t *testing.T) {
+			r := require.New(t)
+			c := successCase()
+			cs.updateCase(c)
+			cm := prom.NewConfigManager()
+			updated := false
+			cm.AddReloadCallbacks(func(c *prom.ConfigInfo) error {
+				updated = true
+				return nil
+			})
+
+			svc := NewService(c.configFile, "", nil, cm, nil, logrus.New())
+			req := &shard.UpdateConfigRequest{
+				RawContent: c.content,
+			}
+			data, _ := json.Marshal(req)
+			r, ret := api.TestCall(t, svc.ginEngine.ServeHTTP, "/api/v1/status/config/", http.MethodPost, string(data), nil)
+			r.Equal(c.wantUpdated, updated)
+			r.Equal(c.wantErr, ret.Status == api.StatusError)
+		})
+	}
 }

--- a/pkg/sidecar/targets_test.go
+++ b/pkg/sidecar/targets_test.go
@@ -31,6 +31,11 @@ import (
 )
 
 func TestTargetsManager_Load(t *testing.T) {
+	tn := time.Now()
+	timeNow = func() time.Time {
+		return tn
+	}
+
 	cases := []struct {
 		name            string
 		fileName        string
@@ -39,10 +44,14 @@ func TestTargetsManager_Load(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name:            "all file not exist, don't return err",
-			fileName:        "", // empty fileName means file not exist
-			wantTargetsInfo: newTargetsInfo(),
-			wantErr:         false,
+			name:     "all file not exist, don't return err",
+			fileName: "", // empty fileName means file not exist
+			wantTargetsInfo: TargetsInfo{
+				Targets: map[string][]*target.Target{},
+				IdleAt:  types.TimePtr(tn),
+				Status:  map[uint64]*target.ScrapeStatus{},
+			},
+			wantErr: false,
 		},
 		{
 			name:         "old version file exist, not format wrong, must return err ",


### PR DESCRIPTION
Add support for no k8s deploy by use static shards config 
![image](https://user-images.githubusercontent.com/23702523/125557051-fb36ba6d-1596-463b-beb2-d2fc1ee270ec.png)

usage of this mode:
**Coordinator**
* set ```--shard.type=static``` 
* set ```--shard.static-file=shards-file```, any change to this file will effect in next period
* example of shards config file 
```
replicas:
- shards:
  - id: shard-0
    url: http://127.0.0.1:8080
```

**Sidecar**
* set ```--config.file=""``` , Sidecar will receive config file from Coordinator instead of reading from local file

