### PR TITLE
add new API endpoint about metrics statistics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM ubuntu:latest
+RUN apt update && apt install -y curl
 COPY kvass /kvass
 ENTRYPOINT ["/kvass"]

--- a/pkg/coordinator/service.go
+++ b/pkg/coordinator/service.go
@@ -98,6 +98,7 @@ func (s *Service) metricsInfo(ctx *gin.Context) *api.Result {
 	for _, ss := range s.getScrapeStatus() {
 		for k, v := range ss.LastMetricsSamples {
 			ret.LastSamples[k] += v
+			ret.SamplesTotal += v
 		}
 	}
 	ret.MetricsTotal = uint64(len(ret.LastSamples))

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -248,3 +248,32 @@ func TestAPI_RuntimeInfo(t *testing.T) {
 	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/shard/runtimeinfo", http.MethodGet, "", res)
 	r.Equal(int64(200), res.HeadSeries)
 }
+
+func TestAPI_MetricsInfo(t *testing.T) {
+	a := NewService("", prom.NewConfigManager(), func() map[uint64]*target.ScrapeStatus {
+		return map[uint64]*target.ScrapeStatus{
+			1: {
+				LastMetricsSamples: map[string]uint64{
+					"a": 1,
+					"b": 2,
+				},
+			},
+			2: {
+				LastMetricsSamples: map[string]uint64{
+					"b": 1,
+					"c": 3,
+				},
+			},
+		}
+	}, nil, nil, prometheus.NewRegistry(), logrus.New())
+	res := &MetricsInfo{}
+	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/metricsinfo", http.MethodGet, "", res)
+	r.Equal(&MetricsInfo{
+		MetricsTotal: 3,
+		LastSamples: map[string]uint64{
+			"a": 1,
+			"b": 3,
+			"c": 3,
+		},
+	}, res)
+}

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -270,6 +270,7 @@ func TestAPI_MetricsInfo(t *testing.T) {
 	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/metricsinfo", http.MethodGet, "", res)
 	r.Equal(&MetricsInfo{
 		MetricsTotal: 3,
+		SamplesTotal: 7,
 		LastSamples: map[string]uint64{
 			"a": 1,
 			"b": 3,

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -24,5 +24,5 @@ type MetricsInfo struct {
 	//
 	SamplesTotal uint64 `json:"samplesTotal"`
 	// LastSamples show the last samples of all metrics
-	LastSamples map[string]uint64
+	LastSamples map[string]uint64 `json:"lastSamples"`
 }

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -1,0 +1,26 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package coordinator
+
+// MetricsInfo contains statistic of metrics
+type MetricsInfo struct {
+	// MetricsTotal show total metrics in last scrape
+	MetricsTotal uint64 `json:"metricsTotal"`
+	// LastSamples show the last samples of all metrics
+	LastSamples map[string]uint64
+}

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -21,6 +21,8 @@ package coordinator
 type MetricsInfo struct {
 	// MetricsTotal show total metrics in last scrape
 	MetricsTotal uint64 `json:"metricsTotal"`
+	//
+	SamplesTotal uint64 `json:"samplesTotal"`
 	// LastSamples show the last samples of all metrics
 	LastSamples map[string]uint64
 }

--- a/pkg/target/status.go
+++ b/pkg/target/status.go
@@ -18,8 +18,9 @@
 package target
 
 import (
-	"github.com/prometheus/prometheus/scrape"
 	"time"
+
+	"github.com/prometheus/prometheus/scrape"
 )
 
 // ScrapeStatus contains last scraping status of the target
@@ -39,8 +40,10 @@ type ScrapeStatus struct {
 	// ScrapeTimes is the times target scraped by this shard
 	ScrapeTimes uint64 `json:"ScrapeTimes"`
 	// Shards contains ID of shards that is scraping this target
-	Shards     []string `json:"shards"`
-	lastSeries []int64
+	Shards []string `json:"shards"`
+	// LastMetricsSamples is metrics sample statistics of last scrape
+	LastMetricsSamples map[string]uint64 `json:"lastMetricsSamples"`
+	lastSeries         []int64
 }
 
 // SetScrapeErr mark the result of this scraping
@@ -48,7 +51,7 @@ type ScrapeStatus struct {
 // health will be up if err is nil
 func (t *ScrapeStatus) SetScrapeErr(start time.Time, err error) {
 	t.LastScrape = start
-	t.LastScrapeDuration = time.Now().Sub(start).Seconds()
+	t.LastScrapeDuration = time.Since(start).Seconds()
 	if err == nil {
 		t.LastError = ""
 		t.Health = scrape.HealthGood
@@ -61,8 +64,9 @@ func (t *ScrapeStatus) SetScrapeErr(start time.Time, err error) {
 // NewScrapeStatus create a new ScrapeStatus with referential series
 func NewScrapeStatus(series int64) *ScrapeStatus {
 	return &ScrapeStatus{
-		Series: series,
-		Health: scrape.HealthUnknown,
+		Series:             series,
+		Health:             scrape.HealthUnknown,
+		LastMetricsSamples: map[string]uint64{},
 	}
 }
 

--- a/pkg/target/status_test.go
+++ b/pkg/target/status_test.go
@@ -19,10 +19,11 @@ package target
 
 import (
 	"fmt"
-	"github.com/prometheus/prometheus/scrape"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScrapeStatus_SetScrapeErr(t *testing.T) {

--- a/pkg/utils/types/strings.go
+++ b/pkg/utils/types/strings.go
@@ -2,6 +2,7 @@ package types
 
 import "strings"
 
+// DeepCopyString deep copy a string with new memory space
 func DeepCopyString(s string) string {
 	var sb strings.Builder
 	sb.WriteString(s)

--- a/pkg/utils/types/strings.go
+++ b/pkg/utils/types/strings.go
@@ -1,0 +1,9 @@
+package types
+
+import "strings"
+
+func DeepCopyString(s string) string {
+	var sb strings.Builder
+	sb.WriteString(s)
+	return sb.String()
+}


### PR DESCRIPTION
add new endpoint of ```Coordinator```
> GET /api/v1/metricsinfo

this endpoint return the metrics statistic of **last scape** 
```
{
  "data": {
    "metricsTotal": 2,
    "samplesTotal": 48,
    "LastSamples": {
      "DCGM_FI_DEV_BOARD_LIMIT_VIOLATION": 24,
      "DCGM_FI_DEV_DEC_UTIL": 24
    }
  }
}
```