### PR TITLE
Feature/support metrics statistics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM ubuntu:latest
+RUN apt update && apt install -y curl
 COPY kvass /kvass
 ENTRYPOINT ["/kvass"]

--- a/cmd/kvass/coordinator.go
+++ b/cmd/kvass/coordinator.go
@@ -315,8 +315,12 @@ func configInjectServiceAccount(job *config.ScrapeConfig, option *configInjectOp
 			job.HTTPClientConfig.TLSConfig.CAFile = path.Join(option.kubernetes.serviceAccountPath, "ca.crt")
 		}
 
-		if job.HTTPClientConfig.BearerTokenFile == "" || job.HTTPClientConfig.BearerTokenFile == "/var/run/secrets/kubernetes.io/serviceaccount/token" {
+		if job.HTTPClientConfig.BearerTokenFile == "/var/run/secrets/kubernetes.io/serviceaccount/token" {
 			job.HTTPClientConfig.BearerTokenFile = path.Join(option.kubernetes.serviceAccountPath, "token")
+		}
+
+		if job.HTTPClientConfig.Authorization != nil && job.HTTPClientConfig.Authorization.CredentialsFile == "/var/run/secrets/kubernetes.io/serviceaccount/token" {
+			job.HTTPClientConfig.Authorization.CredentialsFile = path.Join(option.kubernetes.serviceAccountPath, "token")
 		}
 	}
 }

--- a/cmd/kvass/coordinator.go
+++ b/cmd/kvass/coordinator.go
@@ -176,6 +176,7 @@ distribution targets to shards`,
 		svc := coordinator.NewService(
 			cdCfg.configFile,
 			cfgManager,
+			cd.LastScrapeStatistics,
 			cd.LastGlobalScrapeStatus,
 			targetDiscovery.ActiveTargets,
 			targetDiscovery.DropTargets,

--- a/cmd/kvass/sidecar.go
+++ b/cmd/kvass/sidecar.go
@@ -18,8 +18,6 @@
 package main
 
 import (
-	"path"
-
 	"tkestack.io/kvass/pkg/scrape"
 	"tkestack.io/kvass/pkg/sidecar"
 	"tkestack.io/kvass/pkg/target"
@@ -178,14 +176,7 @@ func configInjectSidecar(cfg *config.Config, option *configInjectOption) error {
 	}
 
 	for _, job := range cfg.ScrapeConfigs {
-		if option.kubernetes.serviceAccountPath != "" {
-			if job.HTTPClientConfig.TLSConfig.CAFile == "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" {
-				job.HTTPClientConfig.TLSConfig.CAFile = path.Join(option.kubernetes.serviceAccountPath, "ca.crt")
-			}
-			if job.HTTPClientConfig.BearerTokenFile == "" || job.HTTPClientConfig.BearerTokenFile == "/var/run/secrets/kubernetes.io/serviceaccount/token" {
-				job.HTTPClientConfig.BearerTokenFile = path.Join(option.kubernetes.serviceAccountPath, "token")
-			}
-		}
+		configInjectServiceAccount(job, option)
 	}
 	return nil
 }

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -148,15 +148,15 @@ func (c *Coordinator) LastScrapeStatistics(jobName string, withMetricsDetail boo
 						rp[job] = item
 					}
 
-					item.ScrappedTotal += result.ScrappedTotal
+					item.ScrapedTotal += result.ScrapedTotal
 					for k, m := range result.MetricsTotal {
 						mi := item.MetricsTotal[k]
 						if mi == nil {
 							mi = &scrape.MetricSamplesInfo{}
 							item.MetricsTotal[k] = mi
 						}
-						mi.Total += m.Scrapped
-						mi.Scrapped += m.Scrapped
+						mi.Total += m.Total
+						mi.Scraped += m.Scraped
 					}
 				}
 				return nil

--- a/pkg/coordinator/coordinator_test.go
+++ b/pkg/coordinator/coordinator_test.go
@@ -70,9 +70,10 @@ func (f *fakeShardsManager) Shards() ([]*shard.Shard, error) {
 		temp := s
 		sd.APIGet = func(url string, ret interface{}) error {
 			dm := map[string]interface{}{
-				"/api/v1/shard/targets/":     temp.targetStatus,
-				"/api/v1/shard/runtimeinfo/": temp.rtInfo,
-				"/api/v1/shard/samples/":     temp.samplesInfo,
+				"/api/v1/shard/targets/":        temp.targetStatus,
+				"/api/v1/shard/targets/status/": temp.targetStatus,
+				"/api/v1/shard/runtimeinfo/":    temp.rtInfo,
+				"/api/v1/shard/samples/":        temp.samplesInfo,
 			}
 			return test.CopyJSON(ret, dm[url])
 		}

--- a/pkg/coordinator/coordinator_test.go
+++ b/pkg/coordinator/coordinator_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	kscrape "tkestack.io/kvass/pkg/scrape"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/sirupsen/logrus"
@@ -39,6 +41,7 @@ type testingShard struct {
 	targetStatus  map[uint64]*target.ScrapeStatus
 	resultTargets shard.UpdateTargetsRequest
 	wantTargets   shard.UpdateTargetsRequest
+	samplesInfo   map[uint64]*kscrape.StatisticsSeriesResult
 }
 
 func (ts *testingShard) assert(t *testing.T) {
@@ -69,6 +72,7 @@ func (f *fakeShardsManager) Shards() ([]*shard.Shard, error) {
 			dm := map[string]interface{}{
 				"/api/v1/shard/targets/":     temp.targetStatus,
 				"/api/v1/shard/runtimeinfo/": temp.rtInfo,
+				"/api/v1/shard/samples/":     temp.samplesInfo,
 			}
 			return test.CopyJSON(ret, dm[url])
 		}
@@ -651,4 +655,8 @@ func TestCoordinator_LastGlobalScrapeStatus(t *testing.T) {
 	g := c.LastGlobalScrapeStatus()
 	r.NotNil(g[1])
 	r.NotNil(g[2])
+}
+
+func TestCoordinator_LastScrapeStatistics(t *testing.T) {
+
 }

--- a/pkg/coordinator/service.go
+++ b/pkg/coordinator/service.go
@@ -122,10 +122,10 @@ func (s *Service) samples(ctx *gin.Context) *api.Result {
 		}
 
 		t := float64(job.ScrapeInterval / model.Duration(time.Second))
-		sm.ScrappedTotal /= t
+		sm.ScrapedTotal /= t
 		for _, m := range sm.MetricsTotal {
 			m.Total /= t
-			m.Scrapped /= t
+			m.Scraped /= t
 		}
 		ret[job.JobName] = sm
 	}

--- a/pkg/coordinator/service.go
+++ b/pkg/coordinator/service.go
@@ -98,6 +98,7 @@ func (s *Service) metricsInfo(ctx *gin.Context) *api.Result {
 	for _, ss := range s.getScrapeStatus() {
 		for k, v := range ss.LastMetricsSamples {
 			ret.LastSamples[k] += v
+			ret.SamplesTotal += v
 		}
 	}
 	ret.MetricsTotal = uint64(len(ret.LastSamples))

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -248,3 +248,32 @@ func TestAPI_RuntimeInfo(t *testing.T) {
 	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/shard/runtimeinfo", http.MethodGet, "", res)
 	r.Equal(int64(200), res.HeadSeries)
 }
+
+func TestAPI_MetricsInfo(t *testing.T) {
+	a := NewService("", prom.NewConfigManager(), func() map[uint64]*target.ScrapeStatus {
+		return map[uint64]*target.ScrapeStatus{
+			1: {
+				LastMetricsSamples: map[string]uint64{
+					"a": 1,
+					"b": 2,
+				},
+			},
+			2: {
+				LastMetricsSamples: map[string]uint64{
+					"b": 1,
+					"c": 3,
+				},
+			},
+		}
+	}, nil, nil, prometheus.NewRegistry(), logrus.New())
+	res := &MetricsInfo{}
+	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/metricsinfo", http.MethodGet, "", res)
+	r.Equal(&MetricsInfo{
+		MetricsTotal: 3,
+		LastSamples: map[string]uint64{
+			"a": 1,
+			"b": 3,
+			"c": 3,
+		},
+	}, res)
+}

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -270,6 +270,7 @@ func TestAPI_MetricsInfo(t *testing.T) {
 	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/metricsinfo", http.MethodGet, "", res)
 	r.Equal(&MetricsInfo{
 		MetricsTotal: 3,
+		SamplesTotal: 7,
 		LastSamples: map[string]uint64{
 			"a": 1,
 			"b": 3,

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -245,6 +245,6 @@ func TestAPI_RuntimeInfo(t *testing.T) {
 		}
 	}, nil, nil, prometheus.NewRegistry(), logrus.New())
 	res := &shard.RuntimeInfo{}
-	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/shard/runtimeinfo", http.MethodGet, "", res)
+	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/runtimeinfo", http.MethodGet, "", res)
 	r.Equal(int64(200), res.HeadSeries)
 }

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -217,7 +217,7 @@ func TestAPI_Targets(t *testing.T) {
 	}
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
-			a := NewService("", prom.NewConfigManager(), getScrapeStatus, getActive, getDrop,
+			a := NewService("", prom.NewConfigManager(), nil, getScrapeStatus, getActive, getDrop,
 				prometheus.NewRegistry(), logrus.New())
 			uri := "/api/v1/targets"
 			if len(cs.param) != 0 {
@@ -234,7 +234,7 @@ func TestAPI_Targets(t *testing.T) {
 }
 
 func TestAPI_RuntimeInfo(t *testing.T) {
-	a := NewService("", prom.NewConfigManager(), func() map[uint64]*target.ScrapeStatus {
+	a := NewService("", prom.NewConfigManager(), nil, func() map[uint64]*target.ScrapeStatus {
 		return map[uint64]*target.ScrapeStatus{
 			1: {
 				Series: 100,
@@ -247,34 +247,4 @@ func TestAPI_RuntimeInfo(t *testing.T) {
 	res := &shard.RuntimeInfo{}
 	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/shard/runtimeinfo", http.MethodGet, "", res)
 	r.Equal(int64(200), res.HeadSeries)
-}
-
-func TestAPI_MetricsInfo(t *testing.T) {
-	a := NewService("", prom.NewConfigManager(), func() map[uint64]*target.ScrapeStatus {
-		return map[uint64]*target.ScrapeStatus{
-			1: {
-				LastMetricsSamples: map[string]uint64{
-					"a": 1,
-					"b": 2,
-				},
-			},
-			2: {
-				LastMetricsSamples: map[string]uint64{
-					"b": 1,
-					"c": 3,
-				},
-			},
-		}
-	}, nil, nil, prometheus.NewRegistry(), logrus.New())
-	res := &MetricsInfo{}
-	r, _ := api.TestCall(t, a.Engine.ServeHTTP, "/api/v1/metricsinfo", http.MethodGet, "", res)
-	r.Equal(&MetricsInfo{
-		MetricsTotal: 3,
-		SamplesTotal: 7,
-		LastSamples: map[string]uint64{
-			"a": 1,
-			"b": 3,
-			"c": 3,
-		},
-	}, res)
 }

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -24,5 +24,5 @@ type MetricsInfo struct {
 	//
 	SamplesTotal uint64 `json:"samplesTotal"`
 	// LastSamples show the last samples of all metrics
-	LastSamples map[string]uint64
+	LastSamples map[string]uint64 `json:"lastSamples"`
 }

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -1,0 +1,26 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package coordinator
+
+// MetricsInfo contains statistic of metrics
+type MetricsInfo struct {
+	// MetricsTotal show total metrics in last scrape
+	MetricsTotal uint64 `json:"metricsTotal"`
+	// LastSamples show the last samples of all metrics
+	LastSamples map[string]uint64
+}

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -21,6 +21,8 @@ package coordinator
 type MetricsInfo struct {
 	// MetricsTotal show total metrics in last scrape
 	MetricsTotal uint64 `json:"metricsTotal"`
+	//
+	SamplesTotal uint64 `json:"samplesTotal"`
 	// LastSamples show the last samples of all metrics
 	LastSamples map[string]uint64
 }

--- a/pkg/coordinator/types.go
+++ b/pkg/coordinator/types.go
@@ -17,12 +17,20 @@
 
 package coordinator
 
-// MetricsInfo contains statistic of metrics
-type MetricsInfo struct {
-	// MetricsTotal show total metrics in last scrape
-	MetricsTotal uint64 `json:"metricsTotal"`
-	//
-	SamplesTotal uint64 `json:"samplesTotal"`
-	// LastSamples show the last samples of all metrics
-	LastSamples map[string]uint64 `json:"lastSamples"`
+// SamplesInfo contains statistic of sample scraped rate
+type SamplesInfo struct {
+	// SamplesRate is total sample rate in last scrape
+	SamplesRate uint64 `json:"samplesRate"`
+	// JobsSamplesRate show total sample rate in last scrape about a job
+	JobsSamplesRate []*JobSamplesInfo `json:"jobsSamplesRate"`
+}
+
+// JobSamplesInfo show total sample rate in last scrape
+type JobSamplesInfo struct {
+	// JobName is the name of this job
+	JobName string `json:"jobName"`
+	// SamplesRateTotal is the total samples rate of this job' targets
+	SamplesRate uint64 `json:"samplesRateTotal"`
+	// MetricsSamplesRate indicate the metrics samples rate
+	MetricsSamplesRate map[string]uint64 `json:"metricsSamplesRate"`
 }

--- a/pkg/explore/explore.go
+++ b/pkg/explore/explore.go
@@ -209,9 +209,9 @@ func (e *Explore) exploreOnce(ctx context.Context, t *exploringTarget) (err erro
 		return errors.Wrapf(err, "explore failed : %s/%s", t.job, url)
 	}
 
-	t.rt.Series = int64(result.ScrappedTotal)
+	t.rt.Series = int64(result.ScrapedTotal)
 
-	t.target.Series = int64(result.ScrappedTotal)
+	t.target.Series = int64(result.ScrapedTotal)
 	t.rt.LastScrapeStatistics = result
 
 	return nil

--- a/pkg/explore/explore.go
+++ b/pkg/explore/explore.go
@@ -64,7 +64,7 @@ type Explore struct {
 
 	retryInterval time.Duration
 	needExplore   chan *exploringTarget
-	explore       func(log logrus.FieldLogger, scrapeInfo *scrape.JobInfo, url string) (int64, error)
+	explore       func(log logrus.FieldLogger, scrapeInfo *scrape.JobInfo, url string) (*scrape.StatisticsSeriesResult, error)
 }
 
 // New create a new Explore
@@ -204,25 +204,28 @@ func (e *Explore) exploreOnce(ctx context.Context, t *exploringTarget) (err erro
 	}
 
 	url := t.target.URL(info.Config).String()
-	series, err := e.explore(e.logger, info, url)
+	result, err := e.explore(e.logger, info, url)
 	if err != nil {
 		return errors.Wrapf(err, "explore failed : %s/%s", t.job, url)
 	}
 
-	t.rt.Series = series
-	t.target.Series = series
+	t.rt.Series = int64(result.ScrappedTotal)
+
+	t.target.Series = int64(result.ScrappedTotal)
+	t.rt.LastScrapeStatistics = result
+
 	return nil
 }
 
-func explore(log logrus.FieldLogger, scrapeInfo *scrape.JobInfo, url string) (int64, error) {
+func explore(log logrus.FieldLogger, scrapeInfo *scrape.JobInfo, url string) (*scrape.StatisticsSeriesResult, error) {
 	scraper := scrape.NewScraper(scrapeInfo, url, log)
 	if err := scraper.RequestTo(); err != nil {
-		return 0, errors.Wrap(err, "request to ")
+		return nil, errors.Wrap(err, "request to ")
 	}
 
-	total := int64(0)
-	return total, scraper.ParseResponse(func(rows []parser.Row) error {
-		total += scrape.StatisticSeries(rows, scrapeInfo.Config.MetricRelabelConfigs)
+	r := scrape.NewStatisticsSeriesResult()
+	return r, scraper.ParseResponse(func(rows []parser.Row) error {
+		scrape.StatisticSeries(rows, scrapeInfo.Config.MetricRelabelConfigs, r)
 		return nil
 	})
 }

--- a/pkg/scrape/scraper.go
+++ b/pkg/scrape/scraper.go
@@ -111,11 +111,11 @@ func (s *Scraper) ParseResponse(do func(rows []parser.Row) error) error {
 
 // StatisticsSeriesResult is the samples count in one scrape
 type StatisticsSeriesResult struct {
-	lk sync.Mutex
-	// ScrappedTotal is samples number total after relabel
-	ScrappedTotal float64
+	lk sync.Mutex `json:"-"`
+	// ScrapedTotal is samples number total after relabel
+	ScrapedTotal float64 `json:"scrapedTotal"`
 	// MetricsTotal is samples number info about all metrics
-	MetricsTotal map[string]*MetricSamplesInfo
+	MetricsTotal map[string]*MetricSamplesInfo `json:"metricsTotal"`
 }
 
 // NewStatisticsSeriesResult return an empty StatisticsSeriesResult
@@ -128,9 +128,9 @@ func NewStatisticsSeriesResult() *StatisticsSeriesResult {
 // MetricSamplesInfo statistics sample about one metric
 type MetricSamplesInfo struct {
 	// Total is total samples appeared in this scape
-	Total float64
-	// Scrapped is samples number after relabel
-	Scrapped float64
+	Total float64 `json:"total"`
+	// Scraped is samples number after relabel
+	Scraped float64 `json:"scraped"`
 }
 
 // StatisticSeries statistic load from metrics raw data
@@ -159,8 +159,8 @@ func StatisticSeries(rows []parser.Row, rc []*relabel.Config, result *Statistics
 		}
 
 		if newSets := relabel.Process(lset, rc...); newSets != nil {
-			result.ScrappedTotal++
-			result.MetricsTotal[n].Scrapped++
+			result.ScrapedTotal++
+			result.MetricsTotal[n].Scraped++
 		}
 	}
 }

--- a/pkg/scrape/scraper_test.go
+++ b/pkg/scrape/scraper_test.go
@@ -47,15 +47,15 @@ func TestStatisticSample(t *testing.T) {
 		},
 	}, r)
 	require.Equal(t, r, &StatisticsSeriesResult{
-		ScrappedTotal: 1,
+		ScrapedTotal: 1,
 		MetricsTotal: map[string]*MetricSamplesInfo{
 			"a": {
-				Total:    1,
-				Scrapped: 0,
+				Total:   1,
+				Scraped: 0,
 			},
 			"b": {
-				Total:    1,
-				Scrapped: 1,
+				Total:   1,
+				Scraped: 1,
 			},
 		},
 	})

--- a/pkg/scrape/scraper_test.go
+++ b/pkg/scrape/scraper_test.go
@@ -19,7 +19,8 @@ import (
 )
 
 func TestStatisticSample(t *testing.T) {
-	total := StatisticSeries([]prometheus.Row{
+	r := NewStatisticsSeriesResult()
+	StatisticSeries([]prometheus.Row{
 		{
 			Metric: "a",
 			Tags: []prometheus.Tag{
@@ -44,8 +45,20 @@ func TestStatisticSample(t *testing.T) {
 			Regex:        relabel.MustNewRegexp("tv"),
 			Action:       relabel.Drop,
 		},
+	}, r)
+	require.Equal(t, r, &StatisticsSeriesResult{
+		ScrappedTotal: 1,
+		MetricsTotal: map[string]*MetricSamplesInfo{
+			"a": {
+				Total:    1,
+				Scrapped: 0,
+			},
+			"b": {
+				Total:    1,
+				Scrapped: 1,
+			},
+		},
 	})
-	require.Equal(t, int64(1), total)
 }
 
 func gzippedData(raw []byte) []byte {

--- a/pkg/shard/shard_test.go
+++ b/pkg/shard/shard_test.go
@@ -151,12 +151,12 @@ func TestShard_Samples(t *testing.T) {
 		detail := ul.Query().Get("with_metrics_detail")
 		data := map[string]*kscrape.StatisticsSeriesResult{}
 		res := kscrape.NewStatisticsSeriesResult()
-		res.ScrappedTotal = 1
+		res.ScrapedTotal = 1
 		if detail == "true" {
 			res.MetricsTotal = map[string]*kscrape.MetricSamplesInfo{
 				"test": {
-					Total:    2,
-					Scrapped: 1,
+					Total:   2,
+					Scraped: 1,
 				},
 			}
 		}
@@ -180,8 +180,8 @@ func TestShard_Samples(t *testing.T) {
 			withDetail: false,
 			wantResult: map[string]*kscrape.StatisticsSeriesResult{
 				"job1": {
-					ScrappedTotal: 1,
-					MetricsTotal:  map[string]*kscrape.MetricSamplesInfo{},
+					ScrapedTotal: 1,
+					MetricsTotal: map[string]*kscrape.MetricSamplesInfo{},
 				},
 			},
 		},
@@ -196,8 +196,8 @@ func TestShard_Samples(t *testing.T) {
 			withDetail: false,
 			wantResult: map[string]*kscrape.StatisticsSeriesResult{
 				"job1": {
-					ScrappedTotal: 1,
-					MetricsTotal:  map[string]*kscrape.MetricSamplesInfo{},
+					ScrapedTotal: 1,
+					MetricsTotal: map[string]*kscrape.MetricSamplesInfo{},
 				},
 			},
 		},
@@ -206,11 +206,11 @@ func TestShard_Samples(t *testing.T) {
 			withDetail: true,
 			wantResult: map[string]*kscrape.StatisticsSeriesResult{
 				"job1": {
-					ScrappedTotal: 1,
+					ScrapedTotal: 1,
 					MetricsTotal: map[string]*kscrape.MetricSamplesInfo{
 						"test": {
-							Total:    2,
-							Scrapped: 1,
+							Total:   2,
+							Scraped: 1,
 						},
 					},
 				},

--- a/pkg/sidecar/proxy.go
+++ b/pkg/sidecar/proxy.go
@@ -128,7 +128,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	proxySeries.WithLabelValues(jobInfo.Config.JobName, realURL.String()).Set(float64(rs.ScrappedTotal))
+	proxySeries.WithLabelValues(jobInfo.Config.JobName, realURL.String()).Set(float64(rs.ScrapedTotal))
 	proxyScrapeDurtion.WithLabelValues(jobInfo.Config.JobName, realURL.String()).Set(float64(time.Now().Sub(start)))
 	if tar != nil {
 		tar.UpdateScrapeResult(rs)

--- a/pkg/sidecar/proxy.go
+++ b/pkg/sidecar/proxy.go
@@ -105,6 +105,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if scrapErr != nil {
 			p.log.Errorf(scrapErr.Error())
 			w.WriteHeader(http.StatusBadRequest)
+			if tar != nil {
+				tar.LastScrapeStatistics = scrape.NewStatisticsSeriesResult()
+			}
 		}
 	}()
 

--- a/pkg/sidecar/service.go
+++ b/pkg/sidecar/service.go
@@ -77,6 +77,9 @@ func NewService(
 	s.ginEngine.GET(s.localPath("/api/v1/shard/targets/status/"), h.Wrap(func(ctx *gin.Context) *api.Result {
 		return api.Data(s.targetManager.TargetsInfo().Status)
 	}))
+	s.ginEngine.GET(s.localPath("/api/v1/shard/targets/"), h.Wrap(func(ctx *gin.Context) *api.Result {
+		return api.Data(s.targetManager.TargetsInfo().Status)
+	}))
 	s.ginEngine.GET(s.localPath("/api/v1/shard/samples/"), h.Wrap(s.samples))
 	s.ginEngine.POST(s.localPath("/api/v1/shard/targets/"), h.Wrap(s.updateTargets))
 	s.ginEngine.POST(s.localPath("/-/reload/"), h.Wrap(func(ctx *gin.Context) *api.Result {

--- a/pkg/sidecar/service.go
+++ b/pkg/sidecar/service.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/cssivision/reverseproxy"
 	"github.com/gin-contrib/pprof"
@@ -29,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"tkestack.io/kvass/pkg/api"
 	"tkestack.io/kvass/pkg/prom"
+	"tkestack.io/kvass/pkg/scrape"
 	"tkestack.io/kvass/pkg/shard"
 	"tkestack.io/kvass/pkg/utils/types"
 )
@@ -72,9 +74,10 @@ func NewService(
 
 	s.ginEngine.GET(s.localPath("/metrics"), h.MetricsHandler)
 	s.ginEngine.GET(s.localPath("/api/v1/shard/runtimeinfo/"), h.Wrap(s.runtimeInfo))
-	s.ginEngine.GET(s.localPath("/api/v1/shard/targets/"), h.Wrap(func(ctx *gin.Context) *api.Result {
+	s.ginEngine.GET(s.localPath("/api/v1/shard/targets/status/"), h.Wrap(func(ctx *gin.Context) *api.Result {
 		return api.Data(s.targetManager.TargetsInfo().Status)
 	}))
+	s.ginEngine.GET(s.localPath("/api/v1/shard/samples/"), h.Wrap(s.samples))
 	s.ginEngine.POST(s.localPath("/api/v1/shard/targets/"), h.Wrap(s.updateTargets))
 	s.ginEngine.POST(s.localPath("/-/reload/"), h.Wrap(func(ctx *gin.Context) *api.Result {
 		if err := s.cfgManager.ReloadFromFile(configFile); err != nil {
@@ -162,4 +165,40 @@ func (s *Service) updateConfig(g *gin.Context) *api.Result {
 	}
 
 	return api.Data(nil)
+}
+
+func (s *Service) samples(ctx *gin.Context) *api.Result {
+	withMetricsDetail := ctx.Query("with_metrics_detail")
+	targetJob := ctx.Query("job")
+	ret := map[string]*scrape.StatisticsSeriesResult{}
+	status := s.targetManager.TargetsInfo().Status
+	for job, ts := range s.targetManager.TargetsInfo().Targets {
+		if targetJob != "" && !strings.Contains(job, targetJob) {
+			continue
+		}
+
+		result := scrape.NewStatisticsSeriesResult()
+		for _, t := range ts {
+			s := status[t.Hash]
+			if s == nil {
+				continue
+			}
+
+			result.ScrappedTotal += s.LastScrapeStatistics.ScrappedTotal
+			if withMetricsDetail == "true" {
+				for k, v := range s.LastScrapeStatistics.MetricsTotal {
+					m := result.MetricsTotal[k]
+					if result.MetricsTotal[k] == nil {
+						m = &scrape.MetricSamplesInfo{}
+						result.MetricsTotal[k] = m
+					}
+					m.Scrapped += v.Scrapped
+					m.Total += v.Total
+				}
+			}
+		}
+		ret[job] = result
+	}
+
+	return api.Data(ret)
 }

--- a/pkg/sidecar/service.go
+++ b/pkg/sidecar/service.go
@@ -184,7 +184,7 @@ func (s *Service) samples(ctx *gin.Context) *api.Result {
 				continue
 			}
 
-			result.ScrappedTotal += s.LastScrapeStatistics.ScrappedTotal
+			result.ScrapedTotal += s.LastScrapeStatistics.ScrapedTotal
 			if withMetricsDetail == "true" {
 				for k, v := range s.LastScrapeStatistics.MetricsTotal {
 					m := result.MetricsTotal[k]
@@ -192,7 +192,7 @@ func (s *Service) samples(ctx *gin.Context) *api.Result {
 						m = &scrape.MetricSamplesInfo{}
 						result.MetricsTotal[k] = m
 					}
-					m.Scrapped += v.Scrapped
+					m.Scraped += v.Scraped
 					m.Total += v.Total
 				}
 			}

--- a/pkg/sidecar/service_test.go
+++ b/pkg/sidecar/service_test.go
@@ -324,11 +324,11 @@ func TestNewService_getJobSamples(t *testing.T) {
 
 		tm.TargetsInfo().Status[1] = &target.ScrapeStatus{
 			LastScrapeStatistics: &scrape.StatisticsSeriesResult{
-				ScrappedTotal: 1,
+				ScrapedTotal: 1,
 				MetricsTotal: map[string]*scrape.MetricSamplesInfo{
 					"test": {
-						Total:    2,
-						Scrapped: 1,
+						Total:   2,
+						Scraped: 1,
 					},
 				},
 			},
@@ -336,15 +336,15 @@ func TestNewService_getJobSamples(t *testing.T) {
 
 		tm.TargetsInfo().Status[2] = &target.ScrapeStatus{
 			LastScrapeStatistics: &scrape.StatisticsSeriesResult{
-				ScrappedTotal: 1,
+				ScrapedTotal: 1,
 				MetricsTotal: map[string]*scrape.MetricSamplesInfo{
 					"test": {
-						Total:    2,
-						Scrapped: 1,
+						Total:   2,
+						Scraped: 1,
 					},
 					"test2": {
-						Total:    1,
-						Scrapped: 0,
+						Total:   1,
+						Scraped: 0,
 					},
 				},
 			},
@@ -355,8 +355,8 @@ func TestNewService_getJobSamples(t *testing.T) {
 			targetManager: tm,
 			wantResutl: map[string]*scrape.StatisticsSeriesResult{
 				"a": {
-					ScrappedTotal: 2,
-					MetricsTotal:  map[string]*scrape.MetricSamplesInfo{},
+					ScrapedTotal: 2,
+					MetricsTotal: map[string]*scrape.MetricSamplesInfo{},
 				},
 			},
 		}
@@ -375,15 +375,15 @@ func TestNewService_getJobSamples(t *testing.T) {
 				c.uri = "/api/v1/shard/samples/?with_metrics_detail=true"
 				c.wantResutl = map[string]*scrape.StatisticsSeriesResult{
 					"a": {
-						ScrappedTotal: 2,
+						ScrapedTotal: 2,
 						MetricsTotal: map[string]*scrape.MetricSamplesInfo{
 							"test": {
-								Total:    4,
-								Scrapped: 2,
+								Total:   4,
+								Scraped: 2,
 							},
 							"test2": {
-								Total:    1,
-								Scrapped: 0,
+								Total:   1,
+								Scraped: 0,
 							},
 						},
 					},

--- a/pkg/target/status.go
+++ b/pkg/target/status.go
@@ -75,11 +75,11 @@ func NewScrapeStatus(series int64) *ScrapeStatus {
 // UpdateScrapeResult statistic target samples info
 func (t *ScrapeStatus) UpdateScrapeResult(r *kscrape.StatisticsSeriesResult) {
 	if len(t.lastSeries) < 3 {
-		t.lastSeries = append(t.lastSeries, int64(r.ScrappedTotal))
+		t.lastSeries = append(t.lastSeries, int64(r.ScrapedTotal))
 	} else {
 		newSeries := make([]int64, 0)
 		newSeries = append(newSeries, t.lastSeries[1:]...)
-		newSeries = append(newSeries, int64(r.ScrappedTotal))
+		newSeries = append(newSeries, int64(r.ScrapedTotal))
 		t.lastSeries = newSeries
 	}
 

--- a/pkg/target/status.go
+++ b/pkg/target/status.go
@@ -18,8 +18,9 @@
 package target
 
 import (
-	"github.com/prometheus/prometheus/scrape"
 	"time"
+
+	"github.com/prometheus/prometheus/scrape"
 )
 
 // ScrapeStatus contains last scraping status of the target
@@ -39,8 +40,10 @@ type ScrapeStatus struct {
 	// ScrapeTimes is the times target scraped by this shard
 	ScrapeTimes uint64 `json:"ScrapeTimes"`
 	// Shards contains ID of shards that is scraping this target
-	Shards     []string `json:"shards"`
-	lastSeries []int64
+	Shards []string `json:"shards"`
+	// LastMetricsSamples is metrics sample statistics of last scrape
+	LastMetricsSamples map[string]uint64 `json:"lastMetricsSamples"`
+	lastSeries         []int64
 }
 
 // SetScrapeErr mark the result of this scraping
@@ -48,7 +51,7 @@ type ScrapeStatus struct {
 // health will be up if err is nil
 func (t *ScrapeStatus) SetScrapeErr(start time.Time, err error) {
 	t.LastScrape = start
-	t.LastScrapeDuration = time.Now().Sub(start).Seconds()
+	t.LastScrapeDuration = time.Since(start).Seconds()
 	if err == nil {
 		t.LastError = ""
 		t.Health = scrape.HealthGood
@@ -61,8 +64,9 @@ func (t *ScrapeStatus) SetScrapeErr(start time.Time, err error) {
 // NewScrapeStatus create a new ScrapeStatus with referential series
 func NewScrapeStatus(series int64) *ScrapeStatus {
 	return &ScrapeStatus{
-		Series: series,
-		Health: scrape.HealthUnknown,
+		Series:             series,
+		Health:             scrape.HealthUnknown,
+		LastMetricsSamples: map[string]uint64{},
 	}
 }
 

--- a/pkg/target/status_test.go
+++ b/pkg/target/status_test.go
@@ -19,10 +19,11 @@ package target
 
 import (
 	"fmt"
-	"github.com/prometheus/prometheus/scrape"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScrapeStatus_SetScrapeErr(t *testing.T) {

--- a/pkg/target/status_test.go
+++ b/pkg/target/status_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/require"
+	kscrape "tkestack.io/kvass/pkg/scrape"
 )
 
 func TestScrapeStatus_SetScrapeErr(t *testing.T) {
@@ -43,9 +44,11 @@ func TestScrapeStatus_SetScrapeErr(t *testing.T) {
 func TestScrapeStatus_UpdateSamples(t *testing.T) {
 	r := require.New(t)
 	st := NewScrapeStatus(1)
-	st.UpdateSeries(2)
-	st.UpdateSeries(2)
-	st.UpdateSeries(2)
-	st.UpdateSeries(2)
+	rs := kscrape.NewStatisticsSeriesResult()
+	rs.ScrappedTotal = 2
+	st.UpdateScrapeResult(rs)
+	st.UpdateScrapeResult(rs)
+	st.UpdateScrapeResult(rs)
+	st.UpdateScrapeResult(rs)
 	r.Equal(int64(2), st.Series)
 }

--- a/pkg/target/status_test.go
+++ b/pkg/target/status_test.go
@@ -45,7 +45,7 @@ func TestScrapeStatus_UpdateSamples(t *testing.T) {
 	r := require.New(t)
 	st := NewScrapeStatus(1)
 	rs := kscrape.NewStatisticsSeriesResult()
-	rs.ScrappedTotal = 2
+	rs.ScrapedTotal = 2
 	st.UpdateScrapeResult(rs)
 	st.UpdateScrapeResult(rs)
 	st.UpdateScrapeResult(rs)

--- a/pkg/utils/types/strings.go
+++ b/pkg/utils/types/strings.go
@@ -2,6 +2,7 @@ package types
 
 import "strings"
 
+// DeepCopyString deep copy a string with new memory space
 func DeepCopyString(s string) string {
 	var sb strings.Builder
 	sb.WriteString(s)

--- a/pkg/utils/types/strings.go
+++ b/pkg/utils/types/strings.go
@@ -1,0 +1,9 @@
+package types
+
+import "strings"
+
+func DeepCopyString(s string) string {
+	var sb strings.Builder
+	sb.WriteString(s)
+	return sb.String()
+}


### PR DESCRIPTION
We want to know the scrape rate for every metrics, so we add flowing API to Sidecar and Coordinator

* Sidecar
> GET /api/v1/shard/samples/?with_metrics_detail=true&&job=xxx
return metrics samples statistics of last scraping, the result  unit is samples total , not rate

* Coordinator
>  GET /api/v1/shard/samples/?with_metrics_detail=true&&job=xxx
return merged samples scraping rate from all shards, the result unit is samples rate, like  10.3/s